### PR TITLE
bugfix: blobname of destination file

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  NAMESPACE: ionos-cloud
+  NAMESPACE: digital-ecosystems
 
 jobs:
   build-and-push-image:

--- a/edc-ionos-extension/data-plane-ionos-s3/src/main/java/com/ionos/edc/dataplane/ionos/s3/IonosDataSink.java
+++ b/edc-ionos-extension/data-plane-ionos-s3/src/main/java/com/ionos/edc/dataplane/ionos/s3/IonosDataSink.java
@@ -33,18 +33,12 @@ public class IonosDataSink extends ParallelSink {
     private String accessKey;
     private String secretkey;
     
-    private IonosDataSink() {
-
-    }
+    private IonosDataSink() {}
 
     @Override
     protected StreamResult<Void> transferParts(List<DataSource.Part> parts) {
         for (DataSource.Part part : parts) {
-        	 String blobName = part.name();
-        
             try (var input = part.openStream()) {
-               
-               
                 s3Api.uploadParts(bucketName, blobName, new ByteArrayInputStream(input.readAllBytes()));
             } catch (Exception e) {
                 return uploadFailure(e, blobName);
@@ -62,7 +56,6 @@ public class IonosDataSink extends ParallelSink {
     }
 
     public static class Builder extends ParallelSink.Builder<Builder, IonosDataSink> {
-
         private Builder() {
             super(new IonosDataSink());
         }
@@ -90,15 +83,13 @@ public class IonosDataSink extends ParallelSink {
             sink.accessKey = accessKey;
             return this;
         }
+
         public Builder secretkey(String secretkey) {
             sink.secretkey = secretkey;
             return this;
         }
 
-
-
         @Override
-        protected void validate() {
-        }
+        protected void validate() {}
     }
 }


### PR DESCRIPTION
**Expected behaviour:**
The blobname set inside the data destination is used for the upload / transfer.

**Current behaviour.**
The blobname of the Stream parts is used which is set by the EDC core to be the name of the datasource instead of the destination source set inside the data sink object.