### PR TITLE
added eu-central-3 to getRegion

### DIFF
--- a/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/api/S3ConnectorApiImpl.java
+++ b/extensions/core-ionos-s3/src/main/java/com/ionos/edc/extension/s3/api/S3ConnectorApiImpl.java
@@ -198,6 +198,10 @@ public class S3ConnectorApiImpl implements S3ConnectorApi {
                 return "eu-central-2";
             case "s3-eu-central-2.ionoscloud.com":
                 return "eu-central-2";
+	    case "https://s3.eu-central-3.ionoscloud.com":
+                return "eu-central-3";
+            case "s3.eu-central-3.ionoscloud.com":
+                return "eu-central-3";
             case "https://s3-eu-south-2.ionoscloud.com":
                 return "eu-south-2";
             case "s3-eu-south-2.ionoscloud.com":


### PR DESCRIPTION
Hello,
I setup some new buckets within Ionos and the shown part failed due to not accounting for the new eu-central-3 region.
I have not checked whether this has broader implications for other parts, just wanted to contribute :)
feel free to close this, if you want to tackle that another way. 